### PR TITLE
use frame-root-window instead of selected-window

### DIFF
--- a/dired-toggle.el
+++ b/dired-toggle.el
@@ -170,7 +170,7 @@ and `dired-hide-details-mode' states after opening new direcoty."
 (defun dired-toggle (&optional dir)
   "Toggle current buffer's directory."
   (interactive)
-  (let* ((win (selected-window))
+  (let* ((win (frame-root-window))
          (buf (buffer-name))
          (file (buffer-file-name))
          (dir (or dir (if file (file-name-directory file) default-directory)))


### PR DESCRIPTION
The original version uses current window as the reference of the newly split dired-toggle-buffer,  but it will be strange when we have 2 window split, like gif below

![Peek 2019-05-05 22-34](https://user-images.githubusercontent.com/32809182/57195506-192a1580-6f86-11e9-832b-86df5315b526.gif)

The new version become 
![Peek 2019-05-05 22-40](https://user-images.githubusercontent.com/32809182/57195560-bdac5780-6f86-11e9-99bd-0d1c1141c375.gif)


works fine even we have more than 2 windows
![Peek 2019-05-05 22-38](https://user-images.githubusercontent.com/32809182/57195548-99507b00-6f86-11e9-8214-4e328430735d.gif)


Hope this helps
